### PR TITLE
Added character 'q' to drpepper font

### DIFF
--- a/Fonts/drpepper/drpepper.h
+++ b/Fonts/drpepper/drpepper.h
@@ -500,17 +500,22 @@ public:
 
     
 
-    /*
+    
         vs q()
         {
-            vs character = getCharGrid(rows,cols);
+            vs character = getCharGrid(4,5);
 
-            //Enter the character grid in ROWS X COLS
+            character[0][0] = character[0][4] = character[1][1] = character[1][3] = character[2][2] = character[2][3] = character[3][0] = character[3][1] = ' ';
+            character[0][1] = character[0][2] = character[0][3] = character[2][1] = character[3][3] = '_';
+            character[1][4] = character[2][4] = character[3][2] = character[3][4] = '|';
+            character[1][0] = '/';
+            character[1][2] = '.';
+            character[2][0] = '\\';
 
             return character;
         }
 
-    */
+    
 
     
         vs r()


### PR DESCRIPTION
Added the character 'q' to the font drpepper.

character added:
![image](https://github.com/user-attachments/assets/24379285-7e08-4194-888b-fadcafc239ab)

character from `drpepper.md`:
![image](https://github.com/user-attachments/assets/5cf27971-3e03-409b-a5dc-3a45e384e463)


### Referenced Issues

closes #1058 